### PR TITLE
.github: Add information about quarantine process to PR

### DIFF
--- a/.github/workflows/review-quarantine-pr.yml
+++ b/.github/workflows/review-quarantine-pr.yml
@@ -1,0 +1,29 @@
+name: Quarantine validation
+
+on:
+  pull_request:
+    branches:
+      - main
+      - v*-branch
+    paths:
+      - '**/scripts/quarantine*.yaml'
+jobs:
+  quarantine-info:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add information about quarantine process
+        run: |
+          # Find existing comment
+          comment_id=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[] | select(.body | contains("Quarantine Process")) | .id' || echo "")
+          if [[ -z "$comment_id" ]]; then
+            # No comment - create new one
+            gh pr comment "$PR_NUMBER" --body "$BODY"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BODY: >
+            Since quarantine was modified, please make sure
+            you are following the process described in
+            [Quarantine Process](https://nordicsemi.atlassian.net/wiki/spaces/NCS/pages/1104576817/Quarantine).


### PR DESCRIPTION
Codeowners should be informed if their test configuration is added to quarantine.
First step is information about quarantine process for author of pull request.